### PR TITLE
B514 pdf generation error no writable cache directories

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -37,7 +37,9 @@ export const handler = async function (
     };
   }
 
-  // add here env variables
+  // Set up writable cache directories for Fontconfig in the /tmp directory
+  process.env.FONTCONFIG_PATH = "/tmp";
+  process.env.FONTCONFIG_FILE = "/tmp/fonts.conf";
 
   const requestData = parsed.data;
 

--- a/index.ts
+++ b/index.ts
@@ -40,6 +40,8 @@ export const handler = async function (
   // Set up writable cache directories for Fontconfig in the /tmp directory
   process.env.FONTCONFIG_PATH = "/tmp";
   process.env.FONTCONFIG_FILE = "/tmp/fonts.conf";
+  process.env.LANG = "C.UTF-8";
+  process.env.LC_ALL = "C.UTF-8";
 
   const requestData = parsed.data;
 

--- a/index.ts
+++ b/index.ts
@@ -37,6 +37,8 @@ export const handler = async function (
     };
   }
 
+  // add here env variables
+
   const requestData = parsed.data;
 
   const region = "eu-west-2";


### PR DESCRIPTION
Sometimes, when generating PDF document, this error occurs:

`Pandoc exited with code 43: Fontconfig error: No writable cache directories\\nFontconfig error: No writable cache directories\\nFontconfig error: No writable cache directories\\nFontconfig error: No writable c ...` (this is repeated several times).

The reason why this error only appears sometimes might be that it only occurs after the cold start of the evaluation function during which the fontconfig manages to create a cache directory, and that remains available during the warm starts, bypassing the error.

I have added:

`process.env.FONTCONFIG_PATH = "/tmp";
  process.env.FONTCONFIG_FILE = "/tmp/fonts.conf";`

...to set writable cache directory to tmp to which the lambda function has write access. That seems to do the trick

There was another problem with locale support. Sometimes this error appeared:

`Pandoc exited with code 43: \\nkpathsea: Running mktexfmt xelatex.fmt\\nperl: warning: Setting locale failed.\\nperl: warning: Please check that your locale settings:\\n\\tLANGUAGE = (unset),\\n\\tLC_ALL = (unset),\\n\\tLANG = \\\"en_US.UTF-8\\\"\\n are supported and installed on your system.\\nperl: warning: Falling back to the standard locale`

To deal with it, I have added:

`  process.env.LANG = "C.UTF-8";
  process.env.LC_ALL = "C.UTF-8";
`