### PR TITLE
D40 add implicit figures for lexical

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -61,7 +61,8 @@ export const handler = async function (
   ) => {
     // pandoc source format 
     // If Milkdown, disable the implicit_figures extension to remove all image captions
-    const fromString = isMilkdown ? "markdown-implicit_figures" : "markdown";
+    // const fromString = isMilkdown ? "markdown-implicit_figures" : "markdown";
+    const fromString = isMilkdown ? "markdown";
 
     try {
       await pdcTs.Execute({

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ export const schema = z.array(
     fileName: z.string(),
     typeOfFile: TypeOfFileSchema,
     markdown: z.string(),
+    isMilkdown: z.boolean().optional(),
   })
 );
 
@@ -55,11 +56,16 @@ export const handler = async function (
   const generateFile = async (
     pandocArgs: string[],
     destFilePath: string,
-    markdown: string
+    markdown: string,
+    isMilkdown: boolean = true
   ) => {
+    // pandoc source format 
+    // If Milkdown, disable the implicit_figures extension to remove all image captions
+    const fromString = isMilkdown ? "markdown-implicit_figures" : "markdown";
+
     try {
       await pdcTs.Execute({
-        from: "markdown-implicit_figures", // pandoc source format (disabling the implicit_figures extension to remove all image captions)
+        from: fromString,
         to: "latex", // pandoc output format
         pandocArgs,
         spawnOpts: { argv0: "+RTS -M512M -RTS" },
@@ -76,7 +82,7 @@ export const handler = async function (
       }
 
       const TeXoutput = await pdcTs.Execute({
-        from: "markdown-implicit_figures", // pandoc source format (disabling the implicit_figures extension to remove all image captions)
+        from: fromString, 
         to: "latex", // pandoc output format
         pandocArgs,
         outputToFile: false, // Controls whether the output will be returned as a string or written to a file
@@ -130,6 +136,7 @@ export const handler = async function (
   let url = "";
   for (let eachRequestData of requestData) {
     const markdown = eachRequestData.markdown;
+    const isMilkdown = eachRequestData.isMilkdown;
 
     switch (eachRequestData.typeOfFile) {
       case "PDF":
@@ -138,7 +145,8 @@ export const handler = async function (
         const generatePDFResult = await generateFile(
           ["--pdf-engine=xelatex", `--template=./template.latex`],
           localPathPDF,
-          markdown
+          markdown,
+          isMilkdown
         );
 
         if (generatePDFResult?.statusCode) {
@@ -154,7 +162,8 @@ export const handler = async function (
         await generateFile(
           [`--template=./template.latex`],
           localPathTEX,
-          markdown
+          markdown,
+          isMilkdown
         );
 
         const s3PathTEX = `${eachRequestData.userId}/${filenameTEX}`;

--- a/index.ts
+++ b/index.ts
@@ -62,7 +62,7 @@ export const handler = async function (
     // pandoc source format 
     // If Milkdown, disable the implicit_figures extension to remove all image captions
     // const fromString = isMilkdown ? "markdown-implicit_figures" : "markdown";
-    const fromString = isMilkdown ? "markdown";
+    const fromString = "markdown";
 
     try {
       await pdcTs.Execute({

--- a/index.ts
+++ b/index.ts
@@ -61,8 +61,8 @@ export const handler = async function (
   ) => {
     // pandoc source format 
     // If Milkdown, disable the implicit_figures extension to remove all image captions
-    // const fromString = isMilkdown ? "markdown-implicit_figures" : "markdown";
-    const fromString = "markdown+implicit_figures";
+    const fromString = isMilkdown ? "markdown-implicit_figures" : "markdown+implicit_figures";
+    // const fromString = "markdown+implicit_figures";
 
     try {
       await pdcTs.Execute({

--- a/index.ts
+++ b/index.ts
@@ -62,7 +62,7 @@ export const handler = async function (
     // pandoc source format 
     // If Milkdown, disable the implicit_figures extension to remove all image captions
     // const fromString = isMilkdown ? "markdown-implicit_figures" : "markdown";
-    const fromString = "markdown";
+    const fromString = "markdown+implicit_figures";
 
     try {
       await pdcTs.Execute({

--- a/src/template.latex
+++ b/src/template.latex
@@ -216,6 +216,10 @@ $if(institute)$
 $endif$
 \date{$date$}
 
+% Set images to stay in place
+\usepackage{float}
+\floatplacement{figure}{H}
+
 % Lambda customisation
 
 \let\OldRule\rule


### PR DESCRIPTION
Trello: https://trello.com/c/Y00aQcrl

# Changes

This PR adds an `isMilkdown` prop to the lambda's schema and uses this to determine whether to produce a PDF with `implicit_figures` enabled or not.