### PR TITLE
D62 Center images

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -59,13 +59,23 @@ export const handler = async function (
     markdown: string,
     implicitFigures: boolean = false
   ) => {
-    // pandoc source format 
-    // If implicitFigures, enable the implicit_figures extension and add image captions
-    const fromString = implicitFigures ? "markdown+implicit_figures" : "markdown-implicit_figures";
+    // Use standard Pandoc style via format name `markdown` 
+    // (see https://pandoc.org/chunkedhtml-demo/3.1-general-options.html)
+    //
+    // The "+implicit_figures" extension wraps images in figures and uses the image's alt text as the caption.
+    // NOTE: The "Figure X." prefix is removed in the LaTeX template via:
+    // ```tex
+    // % Remove "Figure X." prefix from captions
+    // \usepackage{caption}
+    // \captionsetup[figure]{labelformat=empty}
+    // ```
+    //
+    // If `implicitFigures`, enable the `implicit_figures`, disable otherwise...
+    const formatName = implicitFigures ? "markdown+implicit_figures" : "markdown-implicit_figures";
 
     try {
       await pdcTs.Execute({
-        from: fromString,
+        from: formatName,
         to: "latex", // pandoc output format
         pandocArgs,
         spawnOpts: { argv0: "+RTS -M512M -RTS" },
@@ -82,7 +92,7 @@ export const handler = async function (
       }
 
       const TeXoutput = await pdcTs.Execute({
-        from: fromString, 
+        from: formatName, 
         to: "latex", // pandoc output format
         pandocArgs,
         outputToFile: false, // Controls whether the output will be returned as a string or written to a file

--- a/index.ts
+++ b/index.ts
@@ -146,7 +146,7 @@ export const handler = async function (
   let url = "";
   for (let eachRequestData of requestData) {
     const markdown = eachRequestData.markdown;
-    const implicitFigures = true;
+    const implicitFigures = eachRequestData.implicitFigures;
 
     switch (eachRequestData.typeOfFile) {
       case "PDF":

--- a/index.ts
+++ b/index.ts
@@ -146,7 +146,7 @@ export const handler = async function (
   let url = "";
   for (let eachRequestData of requestData) {
     const markdown = eachRequestData.markdown;
-    const implicitFigures = eachRequestData.implicitFigures;
+    const implicitFigures = true;
 
     switch (eachRequestData.typeOfFile) {
       case "PDF":

--- a/src/template.latex
+++ b/src/template.latex
@@ -220,6 +220,31 @@ $endif$
 \usepackage{float}
 \floatplacement{figure}{H}
 
+% Wrap includegaphics in figures with centering...
+\usepackage{etoolbox}  % For toggle functionality
+
+\newtoggle{infigure} % Create toggle to track if we're inside a figure environment
+\togglefalse{infigure}  % Initialize as false
+
+% Set toggle when entering/exiting figure environments
+\pretocmd{\figure}{\toggletrue{infigure}}{}{}
+\apptocmd{\endfigure}{\togglefalse{infigure}}{}{}
+
+% Save the original includegraphics command
+\let\oldincludegraphics\includegraphics
+
+% Redefine includegraphics to check if it's already in a figure
+\renewcommand{\includegraphics}[2][]{%
+  \iftoggle{infigure}{%
+    \oldincludegraphics[#1]{#2}%
+  }{%
+    \begin{figure}
+      \centering
+      \oldincludegraphics[#1]{#2}
+    \end{figure}%
+  }%
+}
+
 % Remove "Figure X." prefix from captions
 \usepackage{caption}
 \captionsetup[figure]{labelformat=empty}

--- a/src/template.latex
+++ b/src/template.latex
@@ -220,21 +220,18 @@ $endif$
 \usepackage{float}
 \floatplacement{figure}{H}
 
-% Wrap includegaphics in figures with centering...
+% Centre images
 \usepackage{etoolbox}  % For toggle functionality
 
 \newtoggle{infigure} % Create toggle to track if we're inside a figure environment
 \togglefalse{infigure}  % Initialize as false
 
-% Set toggle when entering/exiting figure environments
-\pretocmd{\figure}{\toggletrue{infigure}}{}{}
+\pretocmd{\figure}{\toggletrue{infigure}}{}{} % Set toggle when entering/exiting figure environments
 \apptocmd{\endfigure}{\togglefalse{infigure}}{}{}
 
-% Save the original includegraphics command
-\let\oldincludegraphics\includegraphics
+\let\oldincludegraphics\includegraphics % Save the original includegraphics command
 
-% Redefine includegraphics to check if it's already in a figure
-\renewcommand{\includegraphics}[2][]{%
+\renewcommand{\includegraphics}[2][]{ % Redefine includegraphics to check if it's already in a figure
   \iftoggle{infigure}{%
     \oldincludegraphics[#1]{#2}%
   }{%


### PR DESCRIPTION
This PR:

- automatically wraps images in a figure environment if they are not in one and centres them
- changes `fromString` variable name to `formatName`

Apologies about the branch. This was a quick change so I just continued on my last branch. We can delete it after.