### PR TITLE
B699 pdf generator inline images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG NODE_VERSION=20
 # Stage 1: Install pandoc
 FROM public.ecr.aws/lambda/nodejs:${NODE_VERSION} as pandoc
 
-ARG PANDOC_VERSION=3.1.13
+ARG PANDOC_VERSION=3.6.4
 
 # Install tar and gzip
 RUN dnf install -y tar gzip

--- a/src/template.latex
+++ b/src/template.latex
@@ -229,19 +229,6 @@ $endif$
 \pretocmd{\figure}{\toggletrue{infigure}}{}{} % Set toggle when entering/exiting figure environments
 \apptocmd{\endfigure}{\togglefalse{infigure}}{}{}
 
-\let\oldincludegraphics\includegraphics % Save the original includegraphics command
-
-\renewcommand{\includegraphics}[2][]{ % Redefine includegraphics to check if it's already in a figure
-  \iftoggle{infigure}{%
-    \oldincludegraphics[#1]{#2}%
-  }{%
-    \begin{figure}
-      \centering
-      \oldincludegraphics[#1]{#2}
-    \end{figure}%
-  }%
-}
-
 % Remove "Figure X." prefix from captions
 \usepackage{caption}
 \captionsetup[figure]{labelformat=empty}

--- a/src/template.latex
+++ b/src/template.latex
@@ -125,13 +125,23 @@ $endif$
 $if(graphics)$
 \usepackage{graphicx,grffile}
 \makeatletter
-\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
-\def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
-\makeatother
-% Scale images if necessary, so that they will not overflow the page
-% margins by default, and it is still possible to overwrite the defaults
-% using explicit options in \includegraphics[width, height, ...]{}
-\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
+
+% Updating our template following changes to Pandoc
+% https://github.com/jgm/pandoc/pull/9666/files
+
+\newsavebox\pandoc@box
+\newcommand*\pandocbounded[1]{% scales image to fit in text height/width
+  \sbox\pandoc@box{#1}%
+  \Gscale@div\@tempa{\textheight}{\dimexpr\ht\pandoc@box+\dp\pandoc@box\relax}%
+  \Gscale@div\@tempb{\linewidth}{\wd\pandoc@box}%
+  \ifdim\@tempb\p@<\@tempa\p@\let\@tempa\@tempb\fi% select the smaller of both
+  \ifdim\@tempa\p@<\p@\scalebox{\@tempa}{\usebox\pandoc@box}%
+  \else\usebox{\pandoc@box}%
+  \fi%
+}
+
+% End update
+
 $endif$
 $if(links-as-notes)$
 % Make links footnotes instead of hotlinks:

--- a/src/template.latex
+++ b/src/template.latex
@@ -220,15 +220,6 @@ $endif$
 \usepackage{float}
 \floatplacement{figure}{H}
 
-% Centre images
-\let\oldincludegraphics\includegraphics
- 
-\renewcommand{\includegraphics}[2][]{%
-  \begin{center}
-    \oldincludegraphics[#1]{#2}%
-  \end{center}
-}
-
 % Remove "Figure X." prefix from captions
 \usepackage{caption}
 \captionsetup[figure]{labelformat=empty}

--- a/src/template.latex
+++ b/src/template.latex
@@ -221,13 +221,13 @@ $endif$
 \floatplacement{figure}{H}
 
 % Centre images
-\usepackage{etoolbox}  % For toggle functionality
-
-\newtoggle{infigure} % Create toggle to track if we're inside a figure environment
-\togglefalse{infigure}  % Initialize as false
-
-\pretocmd{\figure}{\toggletrue{infigure}}{}{} % Set toggle when entering/exiting figure environments
-\apptocmd{\endfigure}{\togglefalse{infigure}}{}{}
+\let\oldincludegraphics\includegraphics
+ 
+\renewcommand{\includegraphics}[2][]{%
+  \begin{center}
+    \oldincludegraphics[#1]{#2}%
+  \end{center}
+}
 
 % Remove "Figure X." prefix from captions
 \usepackage{caption}


### PR DESCRIPTION
An error occured when there were no images in a question. The source of the error is the update by SEGP to ensure centered images. The error was in the LaTeX template. 

Changes made:
- Update the pandoc version in the dockerfile
- Update the latex template to match changes to pandoc 
- Remove the offending code that caused an error

Testing on local/DEV shows that the error no longer occurs.

An undesirable change is that images without captions are now left aligned. This needs fixing, but the urgent fix is to avoid errors. So this one should go through, and be followed up by a more satisfactory fix to center the images (without affecting pages where there are no images).